### PR TITLE
Allow Nokogiri to upgrade within minor versions

### DIFF
--- a/yquotes.gemspec
+++ b/yquotes.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
 
   spec.add_dependency 'daru', '~> 0.1.5'
-  spec.add_dependency 'nokogiri', '~> 1.7.2'
+  spec.add_dependency 'nokogiri', '~> 1'
 end


### PR DESCRIPTION
Nokogiri is a gem that depends heavily on native code and thus is more prone to having [security issues](https://github.com/sparklemotion/nokogiri/issues?utf8=%E2%9C%93&q=label%3Asecurity).

Since Nokogiri follows semantic versioning, it should be safe to only restrict it to version `1`, allowing users to freely update within that constraint.